### PR TITLE
Knut/libnice turn fixes

### DIFF
--- a/agent/discovery.c
+++ b/agent/discovery.c
@@ -297,13 +297,15 @@ static gboolean priv_add_local_candidate_pruned (NiceAgent *agent, guint stream_
       if (c->type == NICE_CANDIDATE_TYPE_RELAYED &&
           candidate->type == NICE_CANDIDATE_TYPE_RELAYED &&
           nice_address_equal_full (&c->base_addr, &candidate->base_addr, FALSE) &&
-          nice_address_equal_full (&c->addr, &candidate->addr, FALSE)) {
+          nice_address_equal_full (&c->addr, &candidate->addr, FALSE) &&
+          c->turn && candidate->turn && c->turn->type == candidate->turn->type) {
+
         gchar addrstr[INET6_ADDRSTRLEN];
         nice_address_to_string (&c->addr, addrstr);
 
-        GST_DEBUG_OBJECT (agent, "%u/%u: Pruning duplicate relay candidate for srflx address %s (%s %s)",
-            stream_id, component->id, addrstr, candidate->foundation, c->foundation);
-        return FALSE;
+        GST_DEBUG_OBJECT (agent, "%u/%u: Pruning duplicate relay reflexive candidate for relay address %s (%s %s) turn-type:%d",
+            stream_id, component->id, addrstr, candidate->foundation, c->foundation, c->turn->type);
+        return FALSE;          
       }
     }
   }


### PR DESCRIPTION
This PR covers two things:
1) I discovered that the relay candidate pruning I added a couple of weeks back, was a bit too aggressive, and needed additional filtering of relay type.
2) A race in TCP relay setup, where the non-blocking connect can sometimes not have completed until the first send is attempted, causing a stall on any further attempts with that relay server. Only seen on Windows (where it happens often, probably due to slow connect compared to linux, but the fix itself is valid for all platforms.)