### PR TITLE
Knut/ice relay candidates fixes

### DIFF
--- a/agent/agent.c
+++ b/agent/agent.c
@@ -290,6 +290,19 @@ agent_candidate_ice_priority (NiceAgent * agent,
   guint direction_preference = 0;
   guint local_preference = 0;
 
+#if AGENT_EXTENDED_TURN_CANDIDATE_LOGGING
+  if (type == NICE_CANDIDATE_TYPE_RELAYED){
+    if (candidate->turn){
+      gchar * candidate_s = nice_candidate_to_string(candidate);
+      GST_ERROR("TURN-PRIORITY-CALC: %s", candidate_s);
+      g_free(candidate_s);
+    } else {
+      GST_ERROR("No turn server info available for relay candidate!?!?");
+      g_assert_not_reached();
+    }
+  }
+#endif
+
   if (nice_address_is_ipv6 (&candidate->base_addr)) {
     other_preference = candidate->local_foundation;
   } else {

--- a/agent/agent.h
+++ b/agent/agent.h
@@ -113,6 +113,7 @@ typedef struct _NiceAgent NiceAgent;
 #include "candidate.h"
 #include "debug.h"
 
+#define AGENT_EXTENDED_TURN_CANDIDATE_LOGGING 0
 
 G_BEGIN_DECLS
 

--- a/agent/candidate.c
+++ b/agent/candidate.c
@@ -306,3 +306,42 @@ nice_candidate_equal_target (const NiceCandidate *candidate1,
   return (candidate1->transport == candidate2->transport &&
       nice_address_equal (&candidate1->addr, &candidate2->addr));
 }
+
+static const gchar *
+_candidate_relay_type_to_string(NiceRelayType relay_type)
+{
+  switch (relay_type) {
+  case NICE_RELAY_TYPE_TURN_UDP: return "udp";
+  case NICE_RELAY_TYPE_TURN_TCP: return "tcp";
+  case NICE_RELAY_TYPE_TURN_TLS: return "tls";
+  }
+  return "(invalid)";
+}
+
+gchar *
+nice_candidate_to_string(const NiceCandidate * candidate)
+{
+  if (candidate == NULL)
+    return NULL;
+
+  gchar buf[1024];
+  GString * s = g_string_new("candidate");
+  g_string_append_printf(s, " foundation:%s", candidate->foundation);
+  if (candidate->priority)
+    g_string_append_printf(s, " priority:%u", candidate->priority);
+  g_string_append_printf(s, " transport:%s", candidate_transport_to_string(candidate->transport));
+  g_string_append_printf(s, " type:%s", candidate_type_to_string(candidate->type));
+
+  if (candidate->type == NICE_CANDIDATE_TYPE_RELAYED){
+    g_string_append_printf(s, " relay_type:%s", _candidate_relay_type_to_string(candidate->turn->type));
+    nice_address_to_string(&candidate->turn->server, buf);
+    g_string_append_printf(s, " relay_addr:'%s:%d'", buf, nice_address_get_port(&candidate->turn->server));
+  }
+
+  nice_address_to_string(&candidate->addr, buf);
+  g_string_append_printf(s, " addr:'%s:%d'", buf, nice_address_get_port(&candidate->addr));
+  nice_address_to_string(&candidate->base_addr, buf);
+  g_string_append_printf(s, " base_addr:'%s:%d'", buf, nice_address_get_port(&candidate->base_addr));
+
+  return g_string_free(s, FALSE);
+}

--- a/agent/candidate.h
+++ b/agent/candidate.h
@@ -459,4 +459,7 @@ nice_candidate_equal_target (const NiceCandidate *candidate1,
 
 G_END_DECLS
 
+gchar *
+nice_candidate_to_string(const NiceCandidate * candidate);
+
 #endif /* _CANDIDATE_H */

--- a/agent/discovery.c
+++ b/agent/discovery.c
@@ -304,6 +304,12 @@ static gboolean priv_add_local_candidate_pruned (NiceAgent *agent, guint stream_
 
         GST_DEBUG_OBJECT (agent, "%u/%u: Pruning duplicate relay reflexive candidate for relay address %s (%s %s) turn-type:%d",
             stream_id, component->id, addrstr, candidate->foundation, c->foundation, c->turn->type);
+
+#if AGENT_EXTENDED_TURN_CANDIDATE_LOGGING
+        gchar * candidate_s = nice_candidate_to_string(candidate);
+        GST_ERROR("TURN-PRUNE: %s", candidate_s);
+        g_free(candidate_s);
+#endif
         return FALSE;          
       }
     }

--- a/agent/discovery.c
+++ b/agent/discovery.c
@@ -296,7 +296,6 @@ static gboolean priv_add_local_candidate_pruned (NiceAgent *agent, guint stream_
 
       if (c->type == NICE_CANDIDATE_TYPE_RELAYED &&
           candidate->type == NICE_CANDIDATE_TYPE_RELAYED &&
-          nice_address_equal_full (&c->base_addr, &candidate->base_addr, FALSE) &&
           nice_address_equal_full (&c->addr, &candidate->addr, FALSE) &&
           c->turn && candidate->turn && c->turn->type == candidate->turn->type) {
 


### PR DESCRIPTION
Connection towards pexipdemo.com. 
Initial turn servers: turn:e2e-turn.pex.me:443?transport=udp turn:e2e-turn.pex.me:443?transport=tcp -->91.90.45.34
Turn 443 server: turn:no-cn2.pexipdemo.com:443?transport=tcp -->185.35.201.120

**Candidates 0: Before ANY changes.**
```
a=candidate:18 1 udp 1036260095 91.90.45.34 61580 typ relay raddr 172.17.1.1 rport 60735 ufrag fXG2b+LS83ritv9gtOBPm3x+		-> UDP base_addr:'172.17.1.1:60735'
a=candidate:21 1 udp 1036260863 91.90.45.34 64626 typ relay raddr 10.84.19.204 rport 53504 ufrag fXG2b+LS83ritv9gtOBPm3x+	-> UDP base_addr:'10.84.19.204:53504'
a=candidate:21 1 udp 1036260863 91.90.45.34 53840 typ relay raddr 10.84.19.204 rport 49896 ufrag fXG2b+LS83ritv9gtOBPm3x+	-> TCP base_addr:'10.84.19.204:49896'
a=candidate:21 1 udp 1036260863 185.35.201.120 56178 typ relay raddr 10.84.19.204 rport 37902 ufrag fXG2b+LS83ritv9gtOBPm3x+	-> TCP base_addr:'10.84.19.204:37902'
```

**Candidates 1: After rewriting type_preference calculations for candidate prioritisation. [5b82541e2313903d403f1445cfe421a362861a6e]**
```
a=candidate:18 1 udp 1036260095 91.90.45.34 57538 typ relay raddr 172.17.1.1 rport 54977 ufrag 7OqcA4GdlGsCJ7v3SNJAkgQJ -> UDP RELAY base_addr:'172.17.1.1:54977'
a=candidate:21 1 udp 1036260863 91.90.45.34 59744 typ relay raddr 10.84.19.204 rport 38908 ufrag 7OqcA4GdlGsCJ7v3SNJAkgQJ -> UDP RELAY base_addr:'10.84.19.204:38908'
a=candidate:21 1 udp 29627903 91.90.45.34 63350 typ relay raddr 10.84.19.204 rport 46932 ufrag 7OqcA4GdlGsCJ7v3SNJAkgQJ -> TCP RELAY base_addr:'10.84.19.204:46932'
a=candidate:21 1 udp 29627903 185.35.201.120 55893 typ relay raddr 10.84.19.204 rport 42028 ufrag 7OqcA4GdlGsCJ7v3SNJAkgQJ -> TCP RELAY base_addr:'10.84.19.204:42028'
```

**Candidates 2: After foundation filtering for relay candidates. [bf719b293e10b4f3ee8a1905cf96b686c920bcdb]**
```
a=candidate:18 1 udp 1036260095 91.90.45.34 50535 typ relay raddr 172.17.1.1 rport 53874 ufrag qRVVfbfnbMZrMwdrfqzqp5PK  	--> UDP base_addr:'172.17.1.1:53874'
a=candidate:21 1 udp 1036260863 91.90.45.34 58620 typ relay raddr 10.84.19.204 rport 41520 ufrag qRVVfbfnbMZrMwdrfqzqp5PK	--> UDP base_addr:'10.84.19.204:41520'
a=candidate:23 1 udp 29628415 91.90.45.34 63731 typ relay raddr 10.84.19.204 rport 37902 ufrag qRVVfbfnbMZrMwdrfqzqp5PK		--> TCP base_addr:'10.84.19.204:37902'
a=candidate:22 1 udp 29628159 185.35.201.120 56753 typ relay raddr 10.84.19.204 rport 52942 ufrag qRVVfbfnbMZrMwdrfqzqp5PK	--> TCP base_addr:'10.84.19.204:52942'

```
**Candidates 3: After removing base_addr filter for relay server pruning [c9503514b31b778edaa623dd9d5fbfaecf2981d3] (This stage may not really be needed, or even according to RFC, but duplicate relay server entries on the same relay for the different base addresses, seems unnecessary)**
```
a=candidate:18 1 udp 1036260095 91.90.45.34 61977 typ relay raddr 172.17.1.1 rport 48298 ufrag hgPR8I4uX8BFzzYnSbsVFm0v		--> UDP base_addr:'172.17.1.1:48298'
a=candidate:23 1 udp 29628415 91.90.45.34 65088 typ relay raddr 10.84.19.204 rport 51132 ufrag hgPR8I4uX8BFzzYnSbsVFm0v		--> TCP base_addr:'10.84.19.204:51132'
a=candidate:24 1 udp 29628671 185.35.201.120 55698 typ relay raddr 10.84.19.204 rport 55974 ufrag hgPR8I4uX8BFzzYnSbsVFm0v	--> TCP base_addr:'10.84.19.204:55974'
```

Afaik, it does not matter if we get a gap in the foundations, the only important part there is that they are unique.