### PR TITLE
libnice: never evict the nominated pair's remote from valid_candidates

### DIFF
--- a/agent/component.c
+++ b/agent/component.c
@@ -412,11 +412,10 @@ nice_component_add_valid_candidate (NiceAgent *agent, Component *component,
     const NiceCandidate *candidate)
 {
   guint count = 0;
-  GList *item, *last = NULL;
+  GList *item;
 
   for (item = component->valid_candidates; item; item = item->next) {
     NiceCandidate *cand = item->data;
-    last = item;
     count++;
     if (nice_candidate_equal_target (cand, candidate))
       return;
@@ -436,10 +435,29 @@ nice_component_add_valid_candidate (NiceAgent *agent, Component *component,
    * we just keep the list not too long.
    */
   if (count > NICE_COMPONENT_MAX_VALID_CANDIDATES) {
-    NiceCandidate *cand = last->data;
-    component->valid_candidates = g_list_delete_link (
-        component->valid_candidates, last);
-    nice_candidate_free (cand);
+    GList *victim = NULL;
+    GList *i;
+
+    /* Never evict the nominated pair's remote. It is only promoted to the head
+       once media arrives, so under a flood of peer-reflexive candidates it can
+       age out before the first packet - after which every packet from it is
+       rejected by nice_component_verify_remote_candidate() for the whole call. */
+    for (i = g_list_last (component->valid_candidates); i; i = i->prev) {
+      NiceCandidate *cand = i->data;
+
+      if (component->selected_pair.remote != NULL &&
+          nice_candidate_equal_target (cand, component->selected_pair.remote))
+        continue;
+      victim = i;
+      break;
+    }
+
+    if (victim != NULL) {
+      NiceCandidate *cand = victim->data;
+      component->valid_candidates = g_list_delete_link (
+          component->valid_candidates, victim);
+      nice_candidate_free (cand);
+    }
   }
 }
 
@@ -471,5 +489,29 @@ nice_component_verify_remote_candidate (Component *component,
       return TRUE;
     }
   }
+
+  /* The caller drops silently, so make this visible: first occurrence and then
+     every 1000th, with the list we are actually matching against. */
+  component->verify_failures++;
+  if (component->verify_failures == 1 ||
+      (component->verify_failures % 1000) == 0) {
+    char from_str[INET6_ADDRSTRLEN];
+    GString *valid = g_string_new (NULL);
+
+    nice_address_to_string (address, from_str);
+    for (item = component->valid_candidates; item; item = item->next) {
+      NiceCandidate *cand = item->data;
+      char cand_str[INET6_ADDRSTRLEN];
+
+      nice_address_to_string (&cand->addr, cand_str);
+      g_string_append_printf (valid, "%s:%u(type %d) ", cand_str,
+          nice_address_get_port (&cand->addr), cand->type);
+    }
+    GST_WARNING ("verify_remote_candidate FAILED (%u dropped): from %s:%u "
+        "sock %p valid_candidates=[%s]", component->verify_failures, from_str,
+        nice_address_get_port (address), nicesock, valid->str);
+    g_string_free (valid, TRUE);
+  }
+
   return FALSE;
 }

--- a/agent/component.c
+++ b/agent/component.c
@@ -504,10 +504,10 @@ nice_component_verify_remote_candidate (Component *component,
       char cand_str[INET6_ADDRSTRLEN];
 
       nice_address_to_string (&cand->addr, cand_str);
-      g_string_append_printf (valid, "%s:%u(type %d) ", cand_str,
+      g_string_append_printf (valid, "[%s]:%u(type %d) ", cand_str,
           nice_address_get_port (&cand->addr), cand->type);
     }
-    GST_WARNING ("verify_remote_candidate FAILED (%u dropped): from %s:%u "
+    GST_WARNING ("verify_remote_candidate FAILED (%u dropped): from [%s]:%u "
         "sock %p valid_candidates=[%s]", component->verify_failures, from_str,
         nice_address_get_port (address), nicesock, valid->str);
     g_string_free (valid, TRUE);

--- a/agent/component.h
+++ b/agent/component.h
@@ -132,6 +132,7 @@ struct _Component
   gboolean writable;
   gboolean peer_gathering_done;
   gboolean fallback_mode;      /* in this case, accepts packets from all, ignore candidate validation */
+  guint verify_failures;       /* count of packets dropped by verify_remote_candidate */
 };
 
 Component *

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -35,3 +35,15 @@ test_turn_timeout_env = executable('test-turn-timeout-env',
 test('turn-timeout-env', test_turn_timeout_env,
   timeout : 10,
 )
+
+# Unlike the three above, this one links libnice: it calls the real
+# nice_component_add_valid_candidate() / nice_component_verify_remote_candidate()
+# rather than mirroring them, so it cannot drift from the code it guards.
+test_valid_candidate_eviction = executable('test-valid-candidate-eviction',
+  'test-valid-candidate-eviction.c',
+  include_directories : [config_h_inc, libnice_incdir],
+  dependencies : [libagent_dep],
+)
+test('valid-candidate-eviction', test_valid_candidate_eviction,
+  timeout : 10,
+)

--- a/tests/test-valid-candidate-eviction.c
+++ b/tests/test-valid-candidate-eviction.c
@@ -1,0 +1,155 @@
+/*
+ * This file is part of the Nice GLib ICE library.
+ *
+ * Regression test for eviction of the nominated pair's remote candidate from
+ * Component::valid_candidates.
+ *
+ * nice_component_verify_remote_candidate() accepts a packet only if its source
+ * address appears in Component::valid_candidates. That list is capped at
+ * NICE_COMPONENT_MAX_VALID_CANDIDATES and trimmed from the tail by
+ * nice_component_add_valid_candidate().
+ *
+ * A candidate is moved to the head of the list only when a packet from it is
+ * verified, so the nominated pair's remote stays wherever it was inserted until
+ * the first media packet arrives. If enough other candidates are validated in
+ * that window the nominated remote reaches the tail and is evicted, and every
+ * subsequent packet from the peer is dropped as an unknown source for the rest
+ * of the call - silently, since the drop returns 0 with no error and no counter.
+ *
+ * That window is easy to hit when a peer opens one transport per stream and
+ * probes them all: each distinct source port becomes a peer-reflexive candidate.
+ * With 8 audio + 8 video streams a single component was observed accumulating 51
+ * candidates against the cap of 50, i.e. it failed by one.
+ *
+ * (C) 2026 Pexip AS.
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ */
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <glib.h>
+
+#include "agent-priv.h"
+#include "component.h"
+
+#define TEST_PEER_ADDR      "192.0.2.1"
+#define TEST_NOMINATED_PORT 40004
+#define TEST_PRFLX_BASE_PORT 40100
+
+static NiceCandidate *
+make_candidate (guint port, NiceCandidateType type)
+{
+  NiceCandidate *candidate = nice_candidate_new (type);
+
+  candidate->stream_id = 1;
+  candidate->component_id = NICE_COMPONENT_TYPE_RTP;
+  g_assert_true (nice_address_set_from_string (&candidate->addr,
+          TEST_PEER_ADDR));
+  nice_address_set_port (&candidate->addr, port);
+
+  return candidate;
+}
+
+/* Validates candidates the peer never sends media from, as connectivity checks
+ * from one transport per stream do. The agent is only used for logging, so NULL
+ * is fine here. */
+static void
+flood_with_peer_reflexive (Component *component, guint count)
+{
+  guint i;
+
+  for (i = 0; i < count; i++) {
+    NiceCandidate *prflx = make_candidate (TEST_PRFLX_BASE_PORT + i,
+        NICE_CANDIDATE_TYPE_PEER_REFLEXIVE);
+
+    nice_component_add_valid_candidate (NULL, component, prflx);
+    nice_candidate_free (prflx);
+  }
+}
+
+static void
+test_nominated_remote_survives_flood (void)
+{
+  Component *component = component_new (NICE_COMPONENT_TYPE_RTP);
+  NiceCandidate *remote = make_candidate (TEST_NOMINATED_PORT,
+      NICE_CANDIDATE_TYPE_HOST);
+
+  /* Nominate the pair, as component_update_selected_pair() does. */
+  component->selected_pair.remote = remote;
+  nice_component_add_valid_candidate (NULL, component, remote);
+
+  g_assert_true (nice_component_verify_remote_candidate (component,
+          &remote->addr, NULL));
+
+  /* No media has arrived yet, so the nominated remote is never promoted and
+   * ages towards the tail as the flood is prepended. */
+  flood_with_peer_reflexive (component, NICE_COMPONENT_MAX_VALID_CANDIDATES * 2);
+
+  /* Before the fix the nominated remote had been trimmed off the tail and this
+   * failed, dropping every media packet for the remainder of the call. */
+  g_assert_true (nice_component_verify_remote_candidate (component,
+          &remote->addr, NULL));
+
+  component->selected_pair.remote = NULL;
+  nice_candidate_free (remote);
+  component_free (component);
+}
+
+/* The fix must not turn the cap into an unbounded list. */
+static void
+test_list_is_still_bounded (void)
+{
+  Component *component = component_new (NICE_COMPONENT_TYPE_RTP);
+  NiceCandidate *remote = make_candidate (TEST_NOMINATED_PORT,
+      NICE_CANDIDATE_TYPE_HOST);
+
+  component->selected_pair.remote = remote;
+  nice_component_add_valid_candidate (NULL, component, remote);
+
+  flood_with_peer_reflexive (component, NICE_COMPONENT_MAX_VALID_CANDIDATES * 4);
+
+  g_assert_cmpuint (g_list_length (component->valid_candidates), <=,
+      NICE_COMPONENT_MAX_VALID_CANDIDATES + 1);
+
+  component->selected_pair.remote = NULL;
+  nice_candidate_free (remote);
+  component_free (component);
+}
+
+/* Without a nominated pair the original tail-trimming behaviour is unchanged. */
+static void
+test_trims_when_no_pair_nominated (void)
+{
+  Component *component = component_new (NICE_COMPONENT_TYPE_RTP);
+  NiceCandidate *oldest = make_candidate (TEST_NOMINATED_PORT,
+      NICE_CANDIDATE_TYPE_HOST);
+
+  nice_component_add_valid_candidate (NULL, component, oldest);
+  flood_with_peer_reflexive (component, NICE_COMPONENT_MAX_VALID_CANDIDATES * 2);
+
+  g_assert_false (nice_component_verify_remote_candidate (component,
+          &oldest->addr, NULL));
+
+  nice_candidate_free (oldest);
+  component_free (component);
+}
+
+int
+main (int argc, char *argv[])
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/valid-candidate/nominated-remote-survives-flood",
+      test_nominated_remote_survives_flood);
+  g_test_add_func ("/valid-candidate/list-is-still-bounded",
+      test_list_is_still_bounded);
+  g_test_add_func ("/valid-candidate/trims-when-no-pair-nominated",
+      test_trims_when_no_pair_nominated);
+
+  return g_test_run ();
+}


### PR DESCRIPTION
### Symptom
Intermittently, one participant in a distributed (edge + transcoding) conference is neither seen nor heard by the others for the entire call. Media flows normally in every other direction, no error is logged anywhere, and both nodes appear healthy: ICE completes, DTLS is up, the pipeline is fully built, and a packet capture on the receiving node shows the sender's RTP arriving on the wire at full rate for the whole call.
### Root cause
`nice_component_verify_remote_candidate()` accepts a packet only if its source address is in `Component::valid_candidates`. That list is capped at `NICE_COMPONENT_MAX_VALID_CANDIDATES` (50) and trimmed from the tail by `nice_component_add_valid_candidate()`.

A candidate is promoted to the head of the list only when a packet from it is verified. The nominated pair's remote is therefore added once at nomination and then stays put until the first media packet arrives. If enough other candidates are validated in that window, it reaches the tail and is evicted — and every subsequent packet from the peer is dropped as an unknown source, permanently.

That window is easy to hit when a peer opens one transport per stream and probes them all: each distinct source port becomes a peer-reflexive candidate. In an 8-audio + 8-video call, a single component was observed accumulating 51 candidates against the cap of 50 — failing by one.

The drop is completely silent: `_nice_agent_recv()` returns 0, and the caller has no error, no counter, and nothing above `LOG` level. Downstream, the GStreamer `nicesrc` for that leg blocks in `g_main_loop_run()` for the whole call waiting for a buffer that never comes.
### Fix
When trimming, walk from the tail and skip any entry matching `component->selected_pair.remote`, evicting the oldest other candidate instead. Guarded on the remote being set, so behaviour before nomination is unchanged; if every entry matched, nothing is evicted rather than dropping the one candidate we need.

Also adds a `verify_failures` counter and a rate-limited `GST_WARNING` (first occurrence, then every 1000th) that dumps the list being matched against. This failure mode was silent for an entire call, which is what made it expensive to diagnose.
### Test
`tests/test-valid-candidate-eviction.c`, wired into `tests/meson.build`. Unlike the other meson-wired tests it links `libagent_dep` and exercises the real functions rather than mirroring them, so it cannot drift from the code it guards. Three cases: the regression itself, that the list stays bounded, and that trimming is unchanged when no pair is nominated.

### Scope/risk
Behaviour is unchanged unless the list is at its cap and a pair has been nominated. Worst case the list holds one extra entry.

This is a targeted fix for the eviction. The underlying pressure — one transport per stream, generating O(streams) peer-reflexive candidates — is unchanged, and raising the stream count will keep pushing against this and other limits. Bundling streams onto a shared transport would remove the flood at source and is worth considering separately.
